### PR TITLE
Build windows libraries with vs2017 so they link with binaries built with vs2019

### DIFF
--- a/.yamato/build.yml
+++ b/.yamato/build.yml
@@ -7,7 +7,7 @@ build_linux:
   commands:
     - |
       set -euxo pipefail
-      git checkout 93492fec9d33dad3bede1b1db4952b9f914c5349
+      git checkout 308ea14b9613706d1f95f3d508c3a5c4de31d0da
       sudo yum install -y perl-IPC-Cmd curl zip unzip tar gcc-c++ make
       ./bootstrap-vcpkg.sh
       ./vcpkg install opentelemetry-cpp[otlp] --triplet=x64-linux-release
@@ -62,7 +62,7 @@ build_curl_centos7:
   commands:
     - |
       set -euxo pipefail
-      git checkout 93492fec9d33dad3bede1b1db4952b9f914c5349
+      git checkout 308ea14b9613706d1f95f3d508c3a5c4de31d0da
       sudo yum install -y perl-IPC-Cmd curl zip unzip tar gcc-c++ make
       ./bootstrap-vcpkg.sh
       ./vcpkg install curl --triplet=x64-linux-release
@@ -81,7 +81,7 @@ build_mac_amd64:
   commands:
     - |
       set -euxo pipefail
-      git checkout 93492fec9d33dad3bede1b1db4952b9f914c5349
+      git checkout 308ea14b9613706d1f95f3d508c3a5c4de31d0da
       brew install pkg-config
       ./bootstrap-vcpkg.sh
       cp -f triplets/x64-osx.cmake triplets/x64-osx-10.14.cmake
@@ -133,7 +133,7 @@ build_mac_arm64:
   commands:
     - |
       set -euxo pipefail
-      git checkout 93492fec9d33dad3bede1b1db4952b9f914c5349
+      git checkout 308ea14b9613706d1f95f3d508c3a5c4de31d0da
       brew install pkg-config
       ./bootstrap-vcpkg.sh
       cp -f triplets/community/arm64-osx.cmake triplets/community/arm64-osx-10.14.cmake
@@ -179,59 +179,60 @@ build_mac_arm64:
 build_windows:
   name: build windows
   agent:
-    image: build-system/bee-windows-10-vs2019:v0.1.3-1006513
+    image: cds-ops/win10-vs2017:v0.0.7-942646
     flavor: b1.xlarge
     type: Unity::VM
   interpreter: powershell
   commands:
+    - git checkout 308ea14b9613706d1f95f3d508c3a5c4de31d0da
+
     - |
       $ErrorActionPreference = "Stop"
       trap { $host.SetShouldExit(1) }
-      git checkout 93492fec9d33dad3bede1b1db4952b9f914c5349
-      ./bootstrap-vcpkg.bat
-      ./vcpkg install opentelemetry-cpp[otlp]:x64-windows-static
+      .\bootstrap-vcpkg.bat
+      .\vcpkg install opentelemetry-cpp[otlp]:x64-windows-static
       mkdir pkgme
       mkdir pkgme\include
       mkdir pkgme\lib
-      Copy-Item -Force -Path installed\x64-windows-static\lib\libproto*.lib -Destination pkgme/lib/
-      Copy-Item -Force -Path installed\x64-windows-static\lib\libcrypto.lib -Destination pkgme/lib/
-      Copy-Item -Force -Path installed\x64-windows-static\lib\libssl.lib -Destination pkgme/lib/
-      Copy-Item -Force -Path installed\x64-windows-static\lib\opentelemetry*.lib -Destination pkgme/lib/
-      Copy-Item -Force -Path installed\x64-windows-static\lib\libcurl.lib -Destination pkgme/lib/
-      Copy-Item -Force -Path installed\x64-windows-static\lib\zlib.lib -Destination pkgme/lib/
+      Copy-Item -Force -Path installed\x64-windows-static\lib\libproto*.lib -Destination pkgme\lib\
+      Copy-Item -Force -Path installed\x64-windows-static\lib\libcrypto.lib -Destination pkgme\lib\
+      Copy-Item -Force -Path installed\x64-windows-static\lib\libssl.lib -Destination pkgme\lib\
+      Copy-Item -Force -Path installed\x64-windows-static\lib\opentelemetry*.lib -Destination pkgme\lib\
+      Copy-Item -Force -Path installed\x64-windows-static\lib\libcurl.lib -Destination pkgme\lib\
+      Copy-Item -Force -Path installed\x64-windows-static\lib\zlib.lib -Destination pkgme\lib\
       Copy-Item -Force -Recurse -Path installed\x64-windows-static\include\opentelemetry -Destination pkgme\include\opentelemetry
       Copy-Item -Force -Recurse -Path installed\x64-windows-static\include\google -Destination pkgme\include\google
-      echo "# vcpkg's LICENSE.txt" > pkgme/LICENSE.md.utf16
-      echo "" >> pkgme/LICENSE.md.utf16
-      cat LICENSE.txt >> pkgme/LICENSE.md.utf16
-      echo "" >> pkgme/LICENSE.md.utf16
-      echo "# vcpkg's NOTICE.txt" >> pkgme/LICENSE.md.utf16
-      echo "" >> pkgme/LICENSE.md.utf16
-      cat NOTICE.txt >> pkgme/LICENSE.md.utf16
-      echo "" >> pkgme/LICENSE.md.utf16
-      echo "# curl" >> pkgme/LICENSE.md.utf16
-      echo "" >> pkgme/LICENSE.md.utf16
-      cat installed/x64-windows-static/share/curl/copyright >> pkgme/LICENSE.md.utf16
-      echo "" >> pkgme/LICENSE.md.utf16
-      echo "# openssl" >> pkgme/LICENSE.md.utf16
-      echo "" >> pkgme/LICENSE.md.utf16
-      cat installed/x64-windows-static/share/openssl/copyright >> pkgme/LICENSE.md.utf16
-      echo "" >> pkgme/LICENSE.md.utf16
-      echo "# opentelemetry-cpp" >> pkgme/LICENSE.md.utf16
-      echo "" >> pkgme/LICENSE.md.utf16
-      cat installed/x64-windows-static/share/opentelemetry-cpp/copyright >> pkgme/LICENSE.md.utf16
-      echo "" >> pkgme/LICENSE.md.utf16
-      echo "# protobuf" >> pkgme/LICENSE.md.utf16
-      echo "" >> pkgme/LICENSE.md.utf16
-      cat installed/x64-windows-static/share/protobuf/copyright >> pkgme/LICENSE.md.utf16
-      echo "" >> pkgme/LICENSE.md.utf16
-      echo "# zlib" >> pkgme/LICENSE.md.utf16
-      echo "" >> pkgme/LICENSE.md.utf16
-      cat installed/x64-windows-static/share/zlib/copyright >> pkgme/LICENSE.md.utf16
-      Get-Content pkgme/LICENSE.md.utf16 | Set-Content -Encoding utf8 pkgme/LICENSE.md
-      rm pkgme/LICENSE.md.utf16
+      echo "# vcpkg's LICENSE.txt" > pkgme\LICENSE.md.utf16
+      echo "" >> pkgme\LICENSE.md.utf16
+      cat LICENSE.txt >> pkgme\LICENSE.md.utf16
+      echo "" >> pkgme\LICENSE.md.utf16
+      echo "# vcpkg's NOTICE.txt" >> pkgme\LICENSE.md.utf16
+      echo "" >> pkgme\LICENSE.md.utf16
+      cat NOTICE.txt >> pkgme\LICENSE.md.utf16
+      echo "" >> pkgme\LICENSE.md.utf16
+      echo "# curl" >> pkgme\LICENSE.md.utf16
+      echo "" >> pkgme\LICENSE.md.utf16
+      cat installed\x64-windows-static\share\curl\copyright >> pkgme\LICENSE.md.utf16
+      echo "" >> pkgme\LICENSE.md.utf16
+      echo "# openssl" >> pkgme\LICENSE.md.utf16
+      echo "" >> pkgme\LICENSE.md.utf16
+      cat installed\x64-windows-static\share\openssl\copyright >> pkgme\LICENSE.md.utf16
+      echo "" >> pkgme\LICENSE.md.utf16
+      echo "# opentelemetry-cpp" >> pkgme\LICENSE.md.utf16
+      echo "" >> pkgme\LICENSE.md.utf16
+      cat installed\x64-windows-static\share\opentelemetry-cpp\copyright >> pkgme\LICENSE.md.utf16
+      echo "" >> pkgme\LICENSE.md.utf16
+      echo "# protobuf" >> pkgme\LICENSE.md.utf16
+      echo "" >> pkgme\LICENSE.md.utf16
+      cat installed\x64-windows-static\share\protobuf\copyright >> pkgme\LICENSE.md.utf16
+      echo "" >> pkgme\LICENSE.md.utf16
+      echo "# zlib" >> pkgme\LICENSE.md.utf16
+      echo "" >> pkgme\LICENSE.md.utf16
+      cat installed\x64-windows-static\share\zlib\copyright >> pkgme\LICENSE.md.utf16
+      Get-Content pkgme\LICENSE.md.utf16 | Set-Content -Encoding utf8 pkgme\LICENSE.md
+      rm pkgme\LICENSE.md.utf16
       cd pkgme
-      7z.exe a -tzip ../opentelemetry-cpp-win-amd64.zip *
+      7z.exe a -tzip ..\opentelemetry-cpp-win-amd64.zip *
       cd ..
       rm -r pkgme
   artifacts:


### PR DESCRIPTION
This is an attempt to avoid the errors like the following in our windows minspec tests:
`unresolved external symbol __GSHandlerCheck_EH4`