### PR TITLE
Only build libcurl with vs2017

### DIFF
--- a/.yamato/build.yml
+++ b/.yamato/build.yml
@@ -7,7 +7,7 @@ build_linux:
   commands:
     - |
       set -euxo pipefail
-      git checkout 0cf5b4305ba811d069d3ce328261eeb54bf61c3a
+      git checkout 308ea14b9613706d1f95f3d508c3a5c4de31d0da
       sudo yum install -y perl-IPC-Cmd curl zip unzip tar gcc-c++ make
       ./bootstrap-vcpkg.sh
       ./vcpkg install opentelemetry-cpp[otlp] --triplet=x64-linux-release
@@ -62,7 +62,7 @@ build_curl_centos7:
   commands:
     - |
       set -euxo pipefail
-      git checkout 0cf5b4305ba811d069d3ce328261eeb54bf61c3a
+      git checkout 308ea14b9613706d1f95f3d508c3a5c4de31d0da
       sudo yum install -y perl-IPC-Cmd curl zip unzip tar gcc-c++ make
       ./bootstrap-vcpkg.sh
       ./vcpkg install curl --triplet=x64-linux-release
@@ -81,7 +81,7 @@ build_mac_amd64:
   commands:
     - |
       set -euxo pipefail
-      git checkout 0cf5b4305ba811d069d3ce328261eeb54bf61c3a
+      git checkout 308ea14b9613706d1f95f3d508c3a5c4de31d0da
       brew install pkg-config
       ./bootstrap-vcpkg.sh
       cp -f triplets/x64-osx.cmake triplets/x64-osx-10.14.cmake
@@ -133,7 +133,7 @@ build_mac_arm64:
   commands:
     - |
       set -euxo pipefail
-      git checkout 0cf5b4305ba811d069d3ce328261eeb54bf61c3a
+      git checkout 308ea14b9613706d1f95f3d508c3a5c4de31d0da
       brew install pkg-config
       ./bootstrap-vcpkg.sh
       cp -f triplets/community/arm64-osx.cmake triplets/community/arm64-osx-10.14.cmake
@@ -187,7 +187,7 @@ build_windows:
     - |
       $ErrorActionPreference = "Stop"
       trap { $host.SetShouldExit(1) }
-      git checkout 0cf5b4305ba811d069d3ce328261eeb54bf61c3a
+      git checkout 308ea14b9613706d1f95f3d508c3a5c4de31d0da
       ./bootstrap-vcpkg.bat
       ./vcpkg install opentelemetry-cpp[otlp]:x64-windows-static
       mkdir pkgme

--- a/.yamato/build.yml
+++ b/.yamato/build.yml
@@ -197,7 +197,13 @@ build_windows:
       Copy-Item -Force -Path installed\x64-windows-static\lib\libcrypto.lib -Destination pkgme/lib/
       Copy-Item -Force -Path installed\x64-windows-static\lib\libssl.lib -Destination pkgme/lib/
       Copy-Item -Force -Path installed\x64-windows-static\lib\opentelemetry*.lib -Destination pkgme/lib/
-      Copy-Item -Force -Path installed\x64-windows-static\lib\libcurl.lib -Destination pkgme/lib/
+
+      # libcurl.lib built with vs2019 gives unresolved external symbol __GSHandlerCheck_EH4
+      # errors on win7 (and a bunch of other unresolved symbols). Use a version built with vs2017.
+      # See the build_curl_vs2017 pipeline dependency.
+      #Copy-Item -Force -Path installed\x64-windows-static\lib\libcurl.lib -Destination pkgme\lib\
+      Copy-Item -Force -Path curl-libs\libcurl.lib -Destination pkgme\lib\
+
       Copy-Item -Force -Path installed\x64-windows-static\lib\zlib.lib -Destination pkgme/lib/
       Copy-Item -Force -Recurse -Path installed\x64-windows-static\include\opentelemetry -Destination pkgme\include\opentelemetry
       Copy-Item -Force -Recurse -Path installed\x64-windows-static\include\google -Destination pkgme\include\google
@@ -238,3 +244,27 @@ build_windows:
     opentelemetry-cpp-stevedore-pkg:
       paths:
         - opentelemetry-cpp-win-amd64.zip
+  dependencies:
+    - .yamato/build.yml#build_curl_vs2017
+
+build_curl_vs2017:
+  name: build curl with vs2017
+  agent:
+    image: cds-ops/win10-vs2017:v0.0.7-942646
+    flavor: b1.xlarge
+    type: Unity::VM
+  interpreter: powershell
+  commands:
+    - git checkout 308ea14b9613706d1f95f3d508c3a5c4de31d0da
+
+    - |
+      $ErrorActionPreference = "Stop"
+      trap { $host.SetShouldExit(1) }
+      ./bootstrap-vcpkg.bat
+      ./vcpkg install curl --triplet=x64-windows-static
+      mkdir curl-libs
+      Copy-Item -Force -Path installed\x64-windows-static\lib\* -Destination curl-libs\
+  artifacts:
+    curl-libs:
+      paths:
+        - curl-libs/**


### PR DESCRIPTION
vs2017 produces larger libraries than vs2019, let's try building everything but libcurl with vs2019.